### PR TITLE
feat(package): Allow multiple projects to be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ their github page for any style/linter changes
 - **BREAKING**: Updated `eslint-config-standard` to version `^16.0.3`. Please visit
 their github page for any style/linter changes
 - **Fix**: typo `reqired` to `required`
+- **Feature**: Add support for multiple tsconfig projects to be used
 
 ## 10.0.0
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ the `--project` flag or adding a `ts-standard` configuration property to your `p
 }
 ```
 
+Its possible to specify multiple projects using an array as in the underlying
+[parser](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser#parseroptionsproject).
+
 ## 🗑 Ignoring files and folders
 
 You can ignore files and folders by either providing specific files/globs of the files you want linted
@@ -106,7 +109,7 @@ to `ts-standard` when running the command or you can add an `ignore` property to
     "cwd": "",                  // the root working directory where the project file is located
     "eslint": "",               // path to a custom eslint linter
     "files": [""],              // files/folders/globs to include in the linting
-    "project": "",              // relative path to `tsconfig.json` file
+    "project": "", or [""]      // relative path to `tsconfig.json` file
     "fix": false,               // auto fix any lint errors found that are fixable
     "report": "",               // an eslint formatter to output the lint results as (e.g. standard, stylish, json, etc...)
     "extensions": "",           // a list of file extensions to lint by default (e.g. js,jsx,ts,tsx,mjs,cjs)

--- a/dist/cli.d.ts
+++ b/dist/cli.d.ts
@@ -7,7 +7,7 @@ export interface Options {
     files?: string[];
     test?: string;
     stdIn?: boolean;
-    project?: string;
+    project?: string | string[];
     fix?: boolean;
     report?: string;
     envs?: string[];

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -26,7 +26,8 @@ async function cli() {
     const cliOptions = (0, options_1.getCLIOptions)();
     const options = (0, options_1.mergeOptions)(defaultOptions, packageOptions, cliOptions);
     // Linting requires a project file
-    if (options.project == null) {
+    if (options.project == null ||
+        (Array.isArray(options.project) && options.project.length === 0)) {
         console.error('Unable to locate the project file. A project file (tsconfig.json or ' +
             'tsconfig.eslint.json) is required in order to use ts-standard.');
         return process.exit(1);

--- a/dist/options/cli-options.d.ts
+++ b/dist/options/cli-options.d.ts
@@ -3,7 +3,7 @@ export interface CLIOptions {
     useStdIn: boolean;
     stdInFilename?: string;
     files?: string[];
-    project?: string;
+    project?: string[];
     globals?: string[];
     plugins?: string[];
     envs?: string[];

--- a/dist/options/cli-options.js
+++ b/dist/options/cli-options.js
@@ -71,7 +71,7 @@ Flags (advanced):
         useStdIn: argv.stdin,
         stdInFilename: argv['stdin-filename'],
         files,
-        project: argv.project,
+        project: exports._convertToArray(argv.project),
         globals: exports._convertToArray(argv.globals),
         plugins: exports._convertToArray(argv.plugins),
         envs: exports._convertToArray(argv.envs),

--- a/dist/options/default-options.d.ts
+++ b/dist/options/default-options.d.ts
@@ -9,7 +9,7 @@ export interface DefaultOptions {
     eslint: undefined;
     cwd: string;
     stdInFilename?: string;
-    project?: string;
+    project?: string | string[];
     ignore?: string[];
     envs?: string[];
     globals?: string[];

--- a/dist/options/package-options.d.ts
+++ b/dist/options/package-options.d.ts
@@ -1,6 +1,6 @@
 interface PackageOptions {
     files?: string[];
-    project?: string;
+    project?: string | string[];
     fix?: boolean;
     report?: string;
     ignore?: string[];
@@ -14,5 +14,5 @@ interface PackageOptions {
     extensions?: string[];
 }
 export declare function getPackageOptions(cwd?: string): PackageOptions;
-export declare function _resolveTSConfigPath(cwd: string, settingsProjectPath?: string): string | undefined;
+export declare function _resolveTSConfigPath(cwd: string, settingsProjectPath?: string | string[]): string | string[] | undefined;
 export {};

--- a/dist/options/package-options.js
+++ b/dist/options/package-options.js
@@ -27,9 +27,22 @@ function getPackageOptions(cwd) {
 exports.getPackageOptions = getPackageOptions;
 function _resolveTSConfigPath(cwd, settingsProjectPath) {
     if (settingsProjectPath != null) {
-        const settingsPath = (0, path_1.join)(cwd, settingsProjectPath);
-        if ((0, default_options_1._isValidPath)(settingsPath)) {
-            return settingsPath;
+        if (Array.isArray(settingsProjectPath)) {
+            return settingsProjectPath
+                .map((p) => {
+                const settingsPath = (0, path_1.join)(cwd, p);
+                if ((0, default_options_1._isValidPath)(settingsPath)) {
+                    return settingsPath;
+                }
+                return undefined;
+            })
+                .filter((str) => str !== undefined);
+        }
+        else {
+            const settingsPath = (0, path_1.join)(cwd, settingsProjectPath);
+            if ((0, default_options_1._isValidPath)(settingsPath)) {
+                return settingsPath;
+            }
         }
     }
     return undefined;

--- a/dist/ts-standard.d.ts
+++ b/dist/ts-standard.d.ts
@@ -1,7 +1,7 @@
 import * as eslint from 'eslint';
 import { LintReport } from 'standard-engine';
 export interface Options {
-    project?: string;
+    project?: string | string[];
     fix?: boolean;
     envs?: string[];
     ignore?: string[];

--- a/dist/ts-standard.js
+++ b/dist/ts-standard.js
@@ -13,7 +13,8 @@ class TSStandard {
         const packageOptions = (0, options_1.getPackageOptions)(options.cwd);
         options = (0, options_1.mergeOptions)(defaultOptions, packageOptions, options);
         // Linting requires a project file
-        if (options.project == null) {
+        if (options.project == null ||
+            (Array.isArray(options.project) && options.project.length === 0)) {
             throw new Error('Unable to locate the project file. A project file (tsconfig.json or ' +
                 'tsconfig.eslint.json) is required in order to use ts-standard.');
         }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -532,6 +532,29 @@ describe('cli', () => {
       expect(exitSpy).toHaveBeenCalledWith(1)
     })
 
+    it('should log error if empty project array is provided', async (): Promise<void> => {
+      jest
+        .spyOn(defaultOptionsLib, 'getDefaultOptions')
+        .mockReturnValue({} as any)
+      jest
+        .spyOn(packageOptionsLib, 'getPackageOptions')
+        .mockReturnValue({} as any)
+      jest
+        .spyOn(cliOptionsLib, 'getCLIOptions')
+        .mockReturnValue({ project: [] } as any)
+
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockReturnValue()
+      const exitSpy = jest
+        .spyOn(mockProcess, 'exit')
+        .mockImplementation((() => undefined) as any)
+
+      await cli()
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+      expect(exitSpy).toHaveBeenCalledTimes(1)
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    })
+
     it('should call `lintStdIn` function if `useStdIn` option provided and exit with code 0 if no errors/warnings', async (): Promise<void> => {
       jest
         .spyOn(defaultOptionsLib, 'getDefaultOptions')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ export interface Options {
   test?: string
   stdIn?: boolean
   // Additional options
-  project?: string
+  project?: string | string[]
   fix?: boolean
   report?: string
   envs?: string[]
@@ -59,7 +59,10 @@ export async function cli (): Promise<void> {
   )
 
   // Linting requires a project file
-  if (options.project == null) {
+  if (
+    options.project == null ||
+    (Array.isArray(options.project) && options.project.length === 0)
+  ) {
     console.error(
       'Unable to locate the project file. A project file (tsconfig.json or ' +
         'tsconfig.eslint.json) is required in order to use ts-standard.'

--- a/src/options/cli-options.test.ts
+++ b/src/options/cli-options.test.ts
@@ -155,7 +155,7 @@ describe('tsconfig', () => {
         fix: true,
         useStdIn: false,
         files: ['./**/*.ts'],
-        project: './project-file.json',
+        project: ['./project-file.json'],
         globals: ['$'],
         plugins: ['plugin1'],
         envs: ['env1', 'env2'],

--- a/src/options/cli-options.ts
+++ b/src/options/cli-options.ts
@@ -21,7 +21,7 @@ export interface CLIOptions {
   useStdIn: boolean
   stdInFilename?: string
   files?: string[]
-  project?: string
+  project?: string[]
   globals?: string[]
   plugins?: string[]
   envs?: string[]
@@ -103,7 +103,7 @@ Flags (advanced):
     useStdIn: argv.stdin,
     stdInFilename: argv['stdin-filename'],
     files,
-    project: argv.project,
+    project: exports._convertToArray(argv.project),
     globals: exports._convertToArray(argv.globals),
     plugins: exports._convertToArray(argv.plugins),
     envs: exports._convertToArray(argv.envs),

--- a/src/options/default-options.ts
+++ b/src/options/default-options.ts
@@ -17,7 +17,7 @@ export interface DefaultOptions {
   eslint: undefined
   cwd: string
   stdInFilename?: string
-  project?: string
+  project?: string | string[]
   ignore?: string[]
   envs?: string[]
   globals?: string[]

--- a/src/options/package-options.test.ts
+++ b/src/options/package-options.test.ts
@@ -12,6 +12,15 @@ describe('package-options', () => {
       expect(validPath).toMatch(packageJsonPath)
     })
 
+    it('should return a valid path[] from package.json first', (): void => {
+      jest.spyOn(defaultLib, '_isValidPath').mockReturnValue(true)
+      const validPath = _resolveTSConfigPath(process.cwd(), [
+        packageJsonPath,
+        packageJsonPath
+      ])
+      expect(validPath).toHaveLength(2)
+    })
+
     it('should use provided cwd when resolving the path', (): void => {
       jest.spyOn(defaultLib, '_isValidPath').mockReturnValueOnce(true)
       const validPath = _resolveTSConfigPath('/custom/cwd', packageJsonPath)
@@ -23,6 +32,12 @@ describe('package-options', () => {
       jest.spyOn(defaultLib, '_isValidPath').mockReturnValueOnce(false)
       const validPath = _resolveTSConfigPath(process.cwd(), packageJsonPath)
       expect(validPath).toBeUndefined()
+    })
+
+    it('should return [] if no valid paths found', (): void => {
+      jest.spyOn(defaultLib, '_isValidPath').mockReturnValueOnce(false)
+      const validPath = _resolveTSConfigPath(process.cwd(), [packageJsonPath])
+      expect(validPath).toStrictEqual([])
     })
 
     it('should return undefined if no valid project path given', (): void => {

--- a/src/options/package-options.ts
+++ b/src/options/package-options.ts
@@ -14,7 +14,7 @@ interface PackageConfigOptions extends Config {
   cwd?: string
   eslint?: string
   files?: string[]
-  project?: string
+  project?: string | string[]
   fix?: boolean
   report?: string
   extensions?: string[]
@@ -22,7 +22,7 @@ interface PackageConfigOptions extends Config {
 
 interface PackageOptions {
   files?: string[]
-  project?: string
+  project?: string | string[]
   fix?: boolean
   report?: string
   ignore?: string[]
@@ -58,12 +58,24 @@ export function getPackageOptions (cwd?: string): PackageOptions {
 
 export function _resolveTSConfigPath (
   cwd: string,
-  settingsProjectPath?: string
-): string | undefined {
+  settingsProjectPath?: string | string[]
+): string | string[] | undefined {
   if (settingsProjectPath != null) {
-    const settingsPath = join(cwd, settingsProjectPath)
-    if (_isValidPath(settingsPath)) {
-      return settingsPath
+    if (Array.isArray(settingsProjectPath)) {
+      return settingsProjectPath
+        .map((p) => {
+          const settingsPath = join(cwd, p)
+          if (_isValidPath(settingsPath)) {
+            return settingsPath
+          }
+          return undefined
+        })
+        .filter((str): str is string => str !== undefined)
+    } else {
+      const settingsPath = join(cwd, settingsProjectPath)
+      if (_isValidPath(settingsPath)) {
+        return settingsPath
+      }
     }
   }
   return undefined

--- a/src/ts-standard.ts
+++ b/src/ts-standard.ts
@@ -5,7 +5,7 @@ import { getDefaultOptions, getPackageOptions, mergeOptions } from './options'
 import { CMD, TAGLINE, BUGS_URL, HOMEPAGE, VERSION } from './constants'
 
 export interface Options {
-  project?: string
+  project?: string | string[]
   fix?: boolean
   envs?: string[]
   ignore?: string[]
@@ -43,7 +43,10 @@ export class TSStandard {
     options = mergeOptions(defaultOptions, packageOptions, options)
 
     // Linting requires a project file
-    if (options.project == null) {
+    if (
+      options.project == null ||
+      (Array.isArray(options.project) && options.project.length === 0)
+    ) {
       throw new Error(
         'Unable to locate the project file. A project file (tsconfig.json or ' +
           'tsconfig.eslint.json) is required in order to use ts-standard.'


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Change the `project` config to allow it to accept an array of projects just like the parser does - https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser#parseroptionsproject

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
