### PR TITLE
fix #217: add `@typescript-eslint/parser` to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^4.26.1",
+    "@typescript-eslint/parser": "^4.33.0",
     "eslint": "^7.28.0",
     "eslint-config-standard": "^16.0.3",
     "eslint-config-standard-jsx": "^10.0.0",


### PR DESCRIPTION
## What is the purpose of this pull request?

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[X] Other, please explain:

## What changes did you make?
added a single dependency - `@typescript-eslint/parser` because it is a peer dependency of `@typescript-eslint/eslint-plugin`. `npm` does not warn when installing `ts-standard` and will install `@typescript-eslint/parser` silently, but `yarn` will show a warning.


## Which issue (if any) does this pull request address?
#217 


## Is there anything you'd like reviewers to focus on?
