### PR TITLE
Process `--version` Flag Directly

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -56,6 +56,12 @@ Flags (advanced):
     return
   }
 
+  if (argv.version) {
+    console.log(cliOptions.version)
+    process.exitCode = 0
+    return
+  }
+
   cliOptions.eslintConfig.overrideConfig.parserOptions.project = _getTSConfigPath(
     CURRENT_WORKING_DIRECTORY,
     argv.project

--- a/test/cli.js
+++ b/test/cli.js
@@ -5,7 +5,6 @@ import crossSpawn from 'cross-spawn'
 import options from '../options.js'
 
 const CLI_PATH = fileURLToPath(new URL('../cli.js', import.meta.url))
-const CLI_OPTIONS = fileURLToPath(new URL('../options.js', import.meta.url))
 
 test('command line usage: --help', (t) => {
   t.plan(1)

--- a/test/cli.js
+++ b/test/cli.js
@@ -2,8 +2,10 @@ import { fileURLToPath } from 'node:url'
 
 import test from 'tape'
 import crossSpawn from 'cross-spawn'
+import options from '../options.js'
 
 const CLI_PATH = fileURLToPath(new URL('../cli.js', import.meta.url))
+const CLI_OPTIONS = fileURLToPath(new URL('../options.js', import.meta.url))
 
 test('command line usage: --help', (t) => {
   t.plan(1)
@@ -12,6 +14,23 @@ test('command line usage: --help', (t) => {
   child.on('error', (err) => {
     t.fail(err)
   })
+  child.on('close', (code) => {
+    t.equal(code, 0, 'zero exit code')
+  })
+})
+
+test('command line usage: --version', (t) => {
+  t.plan(2)
+
+  const child = crossSpawn(CLI_PATH, ['--version'])
+  child.on('error', (err) => {
+    t.fail(err)
+  })
+
+  child.stdout.on('data', (data) => {
+    t.equal(data.toString().trim(), options.version, 'version matches')
+  })
+
   child.on('close', (code) => {
     t.equal(code, 0, 'zero exit code')
   })


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Directly process the `--version` flag as per: #263 

**Which issue (if any) does this pull request address?**

#263 

**Is there anything you'd like reviewers to focus on?**

Processing the version flag directly in the `cli.js` module much like the `eslint` project does: https://github.com/eslint/eslint/blob/main/lib/cli.js#L333
