### PR TITLE
chore(release): v12.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 13.0.0 - Pending
 
+## 12.0.1
+
+- **Fix:** Process `--version` Flag Directly without the need of `--project` option [(#264)](https://github.com/standard/ts-standard/pull/264).
+
 ## 12.0.0
 
 - **BREAKING:** Major rewrite of `ts-standard` to follow the structure of other `standard` engines (like `standard`, `semistandard`, `standardx`).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ts-standard",
   "description": "TypeScript Standard Style based on StandardJS",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "main": "./index.js",
   "type": "module",
   "bin": {
@@ -42,7 +42,9 @@
     "tslint"
   ],
   "ts-standard": {
-    "ignore": ["test/fixtures/*.ts"]
+    "ignore": [
+      "test/fixtures/*.ts"
+    ]
   },
   "scripts": {
     "lint:standard": "standard",


### PR DESCRIPTION
Release v12.0.1. :tada:

Version updated and git tag created thanks to the `npm version` command.