### PR TITLE
chore(release): v12.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 13.0.0 - Pending
 
+## 12.0.2
+
+- **Fix:** Allow absolute `--project` path [(#269)](https://github.com/standard/ts-standard/pull/269).
+
 ## 12.0.1
 
 - **Fix:** Process `--version` Flag Directly without the need of `--project` option [(#264)](https://github.com/standard/ts-standard/pull/264).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ts-standard",
   "description": "TypeScript Standard Style based on StandardJS",
-  "version": "12.0.1",
+  "version": "12.0.2",
   "main": "./index.js",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v12.0.2. :tada:

Version updated and git tag created thanks to the `npm version` command.
This time, I should not have forgotten to use `git push --follow-tags`. :sweat_smile:

Fixes #276 
